### PR TITLE
Prevent NCC from running on tag pushes

### DIFF
--- a/.github/workflows/ncc.yml
+++ b/.github/workflows/ncc.yml
@@ -1,6 +1,8 @@
 name: ncc
 on:
   push:
+    tags-ignore:
+      - '**'
     paths:
       - 'package-lock.json'
       - 'src/**'


### PR DESCRIPTION
We can't push a build commit to a tag, so let's not even try to.

We fixed the error message in https://github.com/planningcenter/balto-utils/pull/5, but let's avoid paying for a skipped workflow.