### PR TITLE
🐺 Add `@planningcenter/balto-maintainers` as `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kylemellander @sheck @danielma @molawson
+* @planningcenter/balto-maintainers @kylemellander


### PR DESCRIPTION
We recently added this team to address this need.