### PR TITLE
feat: add ability to set the location of the tsconfig

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'Which check run conclusion type to use when annotations are created ("neutral" or "failure" are most common)'
     required: false
     default: "neutral"
+  tsconfig:
+    description: "Path to the tsconfig.json file. Do not preface with a slash. Example: 'tsconfig.json' or 'src/tsconfig.json'"
+    required: false
+    default: "tsconfig.json"
 outputs:
   issuesCount:
     description: "Number of TypeScript violations found"

--- a/dist/index.js
+++ b/dist/index.js
@@ -13785,13 +13785,15 @@ __nccwpck_require__.r(__webpack_exports__);
 /* harmony import */ var _ClientBase__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(3570);
 
 
-const { GITHUB_WORKSPACE } = process.env
+const { GITHUB_WORKSPACE, INPUT_TSCONFIG } = process.env
 
 const ERROR_REGEX = /(.*\.tsx?)[\(:](.*)[:,].*(error.*)/
 
 class TSCClient extends _ClientBase__WEBPACK_IMPORTED_MODULE_0__/* .ClientBase */ .K {
   get command() {
-    return `${GITHUB_WORKSPACE}/node_modules/.bin/tsc --pretty false`
+    return `${GITHUB_WORKSPACE}/node_modules/.bin/tsc --pretty false${
+      INPUT_TSCONFIG ? ` -p ${GITHUB_WORKSPACE}/${INPUT_TSCONFIG}` : ""
+    }`
   }
 
   get annotations() {

--- a/dist/index.js
+++ b/dist/index.js
@@ -13843,11 +13843,11 @@ __nccwpck_require__.r(__webpack_exports__);
 /* harmony import */ var _ClientBase__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(3570);
 
 
-const { GITHUB_WORKSPACE } = process.env
+const { GITHUB_WORKSPACE, INPUT_TSCONFIG } = process.env
 
 class TSCSilentClient extends _ClientBase__WEBPACK_IMPORTED_MODULE_0__/* .ClientBase */ .K {
   get command() {
-    return `${GITHUB_WORKSPACE}/node_modules/.bin/tsc-silent -p ${GITHUB_WORKSPACE}/tsconfig.json --suppressConfig ${GITHUB_WORKSPACE}/tsc-silent.config.js --compiler ${GITHUB_WORKSPACE}/node_modules/typescript/lib/typescript.js`
+    return `${GITHUB_WORKSPACE}/node_modules/.bin/tsc-silent -p ${GITHUB_WORKSPACE}/${INPUT_TSCONFIG} --suppressConfig ${GITHUB_WORKSPACE}/tsc-silent.config.js --compiler ${GITHUB_WORKSPACE}/node_modules/typescript/lib/typescript.js`
   }
 
   get annotations() {

--- a/src/clients/TSCClient.js
+++ b/src/clients/TSCClient.js
@@ -1,12 +1,14 @@
 import { ClientBase } from "./ClientBase"
 
-const { GITHUB_WORKSPACE } = process.env
+const { GITHUB_WORKSPACE, INPUT_TSCONFIG } = process.env
 
 const ERROR_REGEX = /(.*\.tsx?)[\(:](.*)[:,].*(error.*)/
 
 export class TSCClient extends ClientBase {
   get command() {
-    return `${GITHUB_WORKSPACE}/node_modules/.bin/tsc --pretty false`
+    return `${GITHUB_WORKSPACE}/node_modules/.bin/tsc --pretty false${
+      INPUT_TSCONFIG ? ` -p ${GITHUB_WORKSPACE}/${INPUT_TSCONFIG}` : ""
+    }`
   }
 
   get annotations() {

--- a/src/clients/TSCSilentClient.js
+++ b/src/clients/TSCSilentClient.js
@@ -1,10 +1,10 @@
 import { ClientBase } from "./ClientBase"
 
-const { GITHUB_WORKSPACE } = process.env
+const { GITHUB_WORKSPACE, INPUT_TSCONFIG } = process.env
 
 export class TSCSilentClient extends ClientBase {
   get command() {
-    return `${GITHUB_WORKSPACE}/node_modules/.bin/tsc-silent -p ${GITHUB_WORKSPACE}/tsconfig.json --suppressConfig ${GITHUB_WORKSPACE}/tsc-silent.config.js --compiler ${GITHUB_WORKSPACE}/node_modules/typescript/lib/typescript.js`
+    return `${GITHUB_WORKSPACE}/node_modules/.bin/tsc-silent -p ${GITHUB_WORKSPACE}/${INPUT_TSCONFIG} --suppressConfig ${GITHUB_WORKSPACE}/tsc-silent.config.js --compiler ${GITHUB_WORKSPACE}/node_modules/typescript/lib/typescript.js`
   }
 
   get annotations() {


### PR DESCRIPTION
Now that [tapestry-react](https://github.com/planningcenter/tapestry-react) is fully on TypeScript, it is important for us to not regress when merging PRs.  We'd like to use balto, but it requires us to be able to specify the tsconfig file, because it is a workspace. 

This PR adds support for specifying the location of the tsconfig.